### PR TITLE
Test coverage for fail, fail case

### DIFF
--- a/core/src/test/java/org/typemeta/funcj/control/TryTest.java
+++ b/core/src/test/java/org/typemeta/funcj/control/TryTest.java
@@ -117,6 +117,7 @@ public class TryTest {
         assertEquals("", Try.success(a+b), tiA.and(tiB).map(iA -> iB -> iA + iB));
         assertEquals("", fail, fail.and(tiB).map(iA -> iB -> iA + iB));
         assertEquals("", fail, tiA.and(fail).map(iA -> iB -> iA + iB));
+        assertEquals("", fail, fail.and(fail).map(iA -> iB -> iA + iB));
     }
 
     static class Utils {


### PR DESCRIPTION
The current `TryTest` `andMap` property test has missing coverage.
It covers the cases for (success, success), (success, fail), (fail, success), but not (fail, fail).
This change completes this test's coverage.